### PR TITLE
Add Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,6 +68,17 @@ Style/MethodCallWithArgsParentheses:
   Enabled: true
   IgnoredMethods:
     - 'puts'
+    - 'require'
+    - 'be'
+    - 'to'
+    - 'not_to'
+    - 'describe'
+    - 'context'
+    - 'it'
+    - 'specify'
+    - 'source'
+    - 'add_development_dependency'
+    - 'add_dependency'
 
 Style/NestedParenthesizedCalls:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,74 @@
+Documentation:
+  Enabled: false
+
+# Naming/
+Naming/AccessorMethodName:
+  Enabled: false
+
+Naming/PredicateName:
+  Enabled: false
+
+# Layout/
+Layout/AlignHash:
+  EnforcedColonStyle: table
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/IndentArray:
+  EnforcedStyle: consistent
+
+Layout/SpaceAroundOperators:
+  Enabled: false
+
+# Lint/
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/**/*'
+
+# Metrics/
+Metrics/ClassLength:
+  Max: 360
+
+Metrics/ModuleLength:
+  Max: 360
+
+Metrics/MethodLength:
+  Max: 30
+
+Metrics/AbcSize:
+  Max: 40
+
+Metrics/BlockLength:
+  Enabled: false
+
+# Style/
+Style/TrivialAccessors:
+  IgnoreClassMethods: true
+
+Style/MutableConstant:
+  Enabled: true
+
+Style/MultilineIfModifier:
+  Enabled: false
+
+Style/SignalException:
+  EnforcedStyle: only_fail
+
+Style/DateTime:
+  Enabled: false
+
+Style/FormatStringToken:
+  EnforcedStyle: template
+
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  IgnoredMethods:
+    - 'puts'
+
+Style/NestedParenthesizedCalls:
+  Exclude:
+    - 'spec/**/*'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task(default: :spec)

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "rubocop/beachy"
+require 'bundler/setup'
+require 'rubocop/beachy'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +10,5 @@ require "rubocop/beachy"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start

--- a/lib/rubocop-beachy.rb
+++ b/lib/rubocop-beachy.rb
@@ -1,4 +1,7 @@
-require 'rubocop'
+# rubocop:disable Naming/FileName
 
+require 'rubocop'
 require 'rubocop/beachy/version'
 require 'rubocop/cop/beachy/zero_method'
+
+# rubocop:enable Naming/FileName

--- a/lib/rubocop/beachy.rb
+++ b/lib/rubocop/beachy.rb
@@ -1,7 +1,6 @@
-require "rubocop/beachy/version"
+require 'rubocop/beachy/version'
 
 module Rubocop
   module Beachy
-    # Your code goes here...
   end
 end

--- a/lib/rubocop/beachy/version.rb
+++ b/lib/rubocop/beachy/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Beachy
-    VERSION = '0.1.0'
+    VERSION = '0.1.0'.freeze
   end
 end

--- a/lib/rubocop/cop/beachy/zero_method.rb
+++ b/lib/rubocop/cop/beachy/zero_method.rb
@@ -2,7 +2,7 @@ module RuboCop
   module Cop
     module Beachy
       class ZeroMethod < Cop
-        MSG  = 'Replace with `Fixnum#zero?`.'
+        MSG  = 'Replace with `Fixnum#zero?`.'.freeze
         ZERO = s(:int, 0)
 
         def on_send(node)
@@ -22,10 +22,11 @@ module RuboCop
         end
 
         def offensive?(node)
-          receiver, method, args = *node
+          _receiver, method, args = *node
 
-          return unless [:==, :!=].include?(method)
+          return unless %i[== !=].include?(method)
           return unless args == ZERO
+
           true
         end
       end

--- a/rubocop-beachy.gemspec
+++ b/rubocop-beachy.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rubocop/beachy/version'
 
@@ -9,19 +8,22 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Josh Aronson']
   spec.email         = ['jparonson@gmail.com']
 
-  spec.summary       = %q{Beachy's custom cops}
-  spec.description   = %q{A few style additions that we force on developers.}
+  spec.summary       = "Beachy's custom cops"
+  spec.description   = 'A few style additions that we force on developers.'
   spec.homepage      = 'https://github.com/beachyapp/rubocop-beachy'
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
+  unless spec.respond_to?(:metadata)
+    fail('RubyGems >= 2.0 is required to protect against public gem pushes.')
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.metadata['allowed_push_host'] = 'https://gems.beachyapp.com'
+
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 require 'rubocop/beachy'


### PR DESCRIPTION
We can use:

```
inherit_gem:
  rubocop-beachy: .rubocop.yml
```

In other projects and it will inherit this global config. That way we can keep it in one central repository and only do overrides where necessary.

Also, I've added `Style/MethodCallWithArgsParentheses` and alphabetized the sections.